### PR TITLE
Accept newer versions of dependencies

### DIFF
--- a/u2f.cabal
+++ b/u2f.cabal
@@ -23,15 +23,15 @@ library
   ghc-options: -Wall
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >= 4.8 && < 4.11
-                       , cryptonite >= 0.17 && < 0.21
+  build-depends:       base >= 4.8 && < 5
+                       , cryptonite >= 0.17 && <= 0.25
                        , binary >= 0.8.4.0 && < 0.9
                        , text >= 1.2 && < 1.3
                        , asn1-encoding >= 0.9 && < 0.10
                        , asn1-types >= 0.3.2 && < 0.4
                        , base64-bytestring >= 1.0.0.1 && < 1.0.1.0
                        , cryptohash >= 0.11 && < 0.12
-                       , aeson >= 1.0 && < 1.1
+                       , aeson >= 1.0 && <= 1.4.0.0
                        , bytestring >= 0.10 && < 0.11
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -43,7 +43,7 @@ test-suite hspec-suite
   hs-source-dirs: tests
   default-language:    Haskell2010
   build-depends:  base
-                , hspec >= 2.2 && < 2.3
+                , hspec >= 2.2 && < 2.6
                 , u2f
                 , text
                 , either-unwrap


### PR DESCRIPTION
I used [Stackage LTS 12.9](https://www.stackage.org/lts-12.9), which tests with the latest versions of cryptonite, aeson and 2.5.5 of hspec.

The other dependencies are up to date (with the exception of binary, which has new releases but they're deprecated).