### PR TITLE
Drop crypto hash

### DIFF
--- a/u2f.cabal
+++ b/u2f.cabal
@@ -23,15 +23,15 @@ library
   ghc-options: -Wall
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >= 4.8 && < 4.11
-                       , cryptonite >= 0.17 && < 0.21
+  build-depends:       base >= 4.8 && < 5
+                       , cryptonite >= 0.17 && <= 0.25
                        , binary >= 0.8.4.0 && < 0.9
                        , text >= 1.2 && < 1.3
                        , asn1-encoding >= 0.9 && < 0.10
                        , asn1-types >= 0.3.2 && < 0.4
                        , base64-bytestring >= 1.0.0.1 && < 1.0.1.0
                        , cryptohash >= 0.11 && < 0.12
-                       , aeson >= 1.0 && < 1.1
+                       , aeson >= 1.0 && <= 1.4.0.0
                        , bytestring >= 0.10 && < 0.11
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -43,7 +43,7 @@ test-suite hspec-suite
   hs-source-dirs: tests
   default-language:    Haskell2010
   build-depends:  base
-                , hspec >= 2.2 && < 2.3
+                , hspec >= 2.2 && < 2.6
                 , u2f
                 , text
                 , either-unwrap

--- a/u2f.cabal
+++ b/u2f.cabal
@@ -25,12 +25,12 @@ library
   -- other-extensions:
   build-depends:       base >= 4.8 && < 5
                        , cryptonite >= 0.17 && <= 0.25
+                       , memory
                        , binary >= 0.8.4.0 && < 0.9
                        , text >= 1.2 && < 1.3
                        , asn1-encoding >= 0.9 && < 0.10
                        , asn1-types >= 0.3.2 && < 0.4
                        , base64-bytestring >= 1.0.0.1 && < 1.0.1.0
-                       , cryptohash >= 0.11 && < 0.12
                        , aeson >= 1.0 && <= 1.4.0.0
                        , bytestring >= 0.10 && < 0.11
   hs-source-dirs:      src


### PR DESCRIPTION
(This is branched off #2—after that's merged I can rebase against master to make this diff just this PR if you'd like)

The [cryptohash package](https://hackage.haskell.org/package/cryptohash) has been deprecated and replaced with cryptonite, which this package is already using. Thus, it makes sense to drop the dependency on cryptohash and just use cryptonite.

In cryptonite, the hashing functions return a `Digest` instead of a `ByteString`. Both are instances of `ByteArray` (from the memory package), so we can convert between them using Data.ByteArray.convert. memory is already a transitive dependency via cryptonite, so no new dependency is added.

memory doesn't make any API guarantees, so I'm not sure what's best to put as a version bound. It could be constrained to just the latest version as of now (0.14.16), but that will necessitate updating the u2f package whenever a new memory package comes out. That's fine, it just might be more maintenance hassle than it's worth. I'm open to whatever.